### PR TITLE
GeoJSON Serializable and Deserializable with Jackson JSON mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,5 +33,11 @@
 			<version>${jackson.version}</version>
 			<scope>test</scope>
 		</dependency>
+	 <dependency>
+	  <groupId>com.fasterxml.jackson.core</groupId>
+	  <artifactId>jackson-annotations</artifactId>
+	  <version>2.1.1</version>
+	  <type>jar</type>
+	 </dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
+		<!--		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
 			<version>${jackson.version}</version>
@@ -48,12 +48,25 @@
 			<artifactId>jackson-core-asl</artifactId>
 			<version>${jackson.version}</version>
 			<type>jar</type>
-		</dependency>
+		</dependency>-->
 		<!--		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
 			<version>2.1.1</version>
 			<type>jar</type>
 		</dependency>-->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.1.1</version>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.1.1</version>
+			<scope>test</scope>
+			<type>jar</type>
+		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
 	<properties>
 		<jackson.version>1.9.13</jackson.version>
 		<junit.version>4.11</junit.version>
+	 <maven.compiler.source>1.7</maven.compiler.source>
+	 <maven.compiler.target>1.7</maven.compiler.target>
 	</properties>
 
 	<developers>
@@ -17,6 +19,14 @@
 			<name>Michael Priess</name>
 			<timezone>+2</timezone>
 			<url>http://mpriess.com</url>
+		</developer>
+		<developer>
+			<email>kosgei.kenny@gmail.com</email>
+			<id>kosgeinsky</id>
+			<name>Kenny Kosgei</name>
+			<roles>
+				<role>Contributor</role>
+			</roles>
 		</developer>
 	</developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geojson</groupId>
 	<artifactId>geojson-pojo</artifactId>
@@ -9,8 +9,8 @@
 	<properties>
 		<jackson.version>1.9.13</jackson.version>
 		<junit.version>4.11</junit.version>
-	 <maven.compiler.source>1.7</maven.compiler.source>
-	 <maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
 	</properties>
 
 	<developers>
@@ -44,10 +44,16 @@
 			<type>jar</type>
 		</dependency>
 		<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-core-asl</artifactId>
+			<version>${jackson.version}</version>
+			<type>jar</type>
+		</dependency>
+		<!--		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
 			<version>2.1.1</version>
 			<type>jar</type>
-		</dependency>
+		</dependency>-->
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<name>geojson-pojo</name>
 
 	<properties>
-		<jackson.version>1.9.13</jackson.version>
+		<jackson.version>2.1.1</jackson.version>
 		<junit.version>4.11</junit.version>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
@@ -24,6 +24,7 @@
 			<email>kosgei.kenny@gmail.com</email>
 			<id>kosgeinsky</id>
 			<name>Kenny Kosgei</name>
+			<timezone>+3</timezone>
 			<roles>
 				<role>Contributor</role>
 			</roles>
@@ -37,34 +38,16 @@
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<!--		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>${jackson.version}</version>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-core-asl</artifactId>
-			<version>${jackson.version}</version>
-			<type>jar</type>
-		</dependency>-->
-		<!--		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-annotations</artifactId>
-			<version>2.1.1</version>
-			<type>jar</type>
-		</dependency>-->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.1.1</version>
+			<version>${jackson.version}</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.1.1</version>
+			<version>${jackson.version}</version>
 			<scope>test</scope>
 			<type>jar</type>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,23 +21,23 @@
 	</developers>
 
 	<dependencies>
-	<dependency>
-		<groupId>junit</groupId>
-		<artifactId>junit</artifactId>
-		<version>${junit.version}</version>
-		<scope>test</scope>
-	</dependency>
-	<dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
 			<version>${jackson.version}</version>
-			<scope>test</scope>
+			<type>jar</type>
 		</dependency>
-	 <dependency>
-	  <groupId>com.fasterxml.jackson.core</groupId>
-	  <artifactId>jackson-annotations</artifactId>
-	  <version>2.1.1</version>
-	  <type>jar</type>
-	 </dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.1.1</version>
+			<type>jar</type>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/org/geojson/geometry/Geometry.java
+++ b/src/main/java/org/geojson/geometry/Geometry.java
@@ -2,16 +2,30 @@ package org.geojson.geometry;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_OBJECT, property = "@Class")
+@JsonSubTypes({ @Type(value = Point.class, name = "Point"),
+		@Type(value = MultiPoint.class, name = "MultiPoint"),
+		@Type(value = LineString.class, name = "LineString"),
+		@Type(value = MultiLineString.class, name = "MultiLineString"),
+		@Type(value = Polygon.class, name = "Polygon"),
+		@Type(value = MultiPolygon.class, name = "MultiPolygon"),
+		@Type(value = GeometryCollection.class, name = "GeometryCollection") })
 public class Geometry {
-	
-	protected final String type;
+
+	protected String type;
+
+	public Geometry() {
+	}
 
 	@JsonCreator
-	public Geometry(@JsonProperty("type") String type) {
+	public Geometry( @JsonProperty("type") String type ) {
 		this.type = type;
 	}
-	
+
 	public String getType() {
 		return type;
 	}

--- a/src/main/java/org/geojson/geometry/Geometry.java
+++ b/src/main/java/org/geojson/geometry/Geometry.java
@@ -1,12 +1,12 @@
 package org.geojson.geometry;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.codehaus.jackson.annotate.JsonSubTypes;
+import org.codehaus.jackson.annotate.JsonSubTypes.Type;
+import org.codehaus.jackson.annotate.JsonTypeInfo;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_OBJECT, property = "@Class")
+
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE, include = JsonTypeInfo.As.WRAPPER_OBJECT, property = "objectType")
 @JsonSubTypes({ @Type(value = Point.class, name = "Point"),
 		@Type(value = MultiPoint.class, name = "MultiPoint"),
 		@Type(value = LineString.class, name = "LineString"),
@@ -14,19 +14,17 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 		@Type(value = Polygon.class, name = "Polygon"),
 		@Type(value = MultiPolygon.class, name = "MultiPolygon"),
 		@Type(value = GeometryCollection.class, name = "GeometryCollection") })
-public class Geometry {
+public abstract class Geometry {
 
 	protected String type;
 
-	public Geometry() {
-	}
-
-	@JsonCreator
-	public Geometry( @JsonProperty("type") String type ) {
-		this.type = type;
-	}
 
 	public String getType() {
 		return type;
 	}
+
+	public void setType( String type ) {
+		this.type = type;
+	}
+	
 }

--- a/src/main/java/org/geojson/geometry/Geometry.java
+++ b/src/main/java/org/geojson/geometry/Geometry.java
@@ -1,10 +1,14 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class Geometry {
 	
-	private String type;
-	
-	public Geometry(String type) {
+	protected final String type;
+
+	@JsonCreator
+	public Geometry(@JsonProperty("type") String type) {
 		this.type = type;
 	}
 	

--- a/src/main/java/org/geojson/geometry/Geometry.java
+++ b/src/main/java/org/geojson/geometry/Geometry.java
@@ -1,30 +1,13 @@
 package org.geojson.geometry;
 
-import org.codehaus.jackson.annotate.JsonSubTypes;
-import org.codehaus.jackson.annotate.JsonSubTypes.Type;
-import org.codehaus.jackson.annotate.JsonTypeInfo;
 
 
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NONE, include = JsonTypeInfo.As.WRAPPER_OBJECT, property = "objectType")
-@JsonSubTypes({ @Type(value = Point.class, name = "Point"),
-		@Type(value = MultiPoint.class, name = "MultiPoint"),
-		@Type(value = LineString.class, name = "LineString"),
-		@Type(value = MultiLineString.class, name = "MultiLineString"),
-		@Type(value = Polygon.class, name = "Polygon"),
-		@Type(value = MultiPolygon.class, name = "MultiPolygon"),
-		@Type(value = GeometryCollection.class, name = "GeometryCollection") })
 public abstract class Geometry {
 
 	protected String type;
 
 
-	public String getType() {
-		return type;
-	}
+	public abstract String getType();
 
-	public void setType( String type ) {
-		this.type = type;
-	}
-	
+
 }

--- a/src/main/java/org/geojson/geometry/Geometry.java
+++ b/src/main/java/org/geojson/geometry/Geometry.java
@@ -1,13 +1,15 @@
 package org.geojson.geometry;
 
-
-
 public abstract class Geometry {
 
 	protected String type;
 
+	public Geometry(String type) {
+		this.type = type;
+	}
 
-	public abstract String getType();
-
+	public String getType() {
+		return type;
+	}
 
 }

--- a/src/main/java/org/geojson/geometry/GeometryCollection.java
+++ b/src/main/java/org/geojson/geometry/GeometryCollection.java
@@ -1,17 +1,19 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.List;
 
+@JsonTypeName("GeometryCollection")
 public class GeometryCollection extends Geometry {
 	
 	private List<Geometry> geometries;
-
+	
 	public GeometryCollection() {
 		super(GeometryCollection.class.getSimpleName());
 	}
 	
 	public GeometryCollection(List<Geometry> geometry) {
-		super(GeometryCollection.class.getSimpleName());
+		this();
 		this.geometries = geometry;
 	}
 	

--- a/src/main/java/org/geojson/geometry/GeometryCollection.java
+++ b/src/main/java/org/geojson/geometry/GeometryCollection.java
@@ -1,7 +1,7 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonTypeName;
 
 @JsonTypeName("GeometryCollection")
 public class GeometryCollection extends Geometry {
@@ -14,10 +14,17 @@ public class GeometryCollection extends Geometry {
 	
 	public GeometryCollection(List<Geometry> geometry) {
 		this.geometries = geometry;
-		setType( GeometryCollection.class.getSimpleName() );
+//		setType( GeometryCollection.class.getSimpleName() );
 	}
 	
 	public List<Geometry> getGeometries() {
 		return geometries;
 	}
+
+	@Override
+	public String getType() {
+		return GeometryCollection.class.getSimpleName();
+	}
+	
+	
 }

--- a/src/main/java/org/geojson/geometry/GeometryCollection.java
+++ b/src/main/java/org/geojson/geometry/GeometryCollection.java
@@ -4,14 +4,18 @@ import java.util.List;
 
 public class GeometryCollection extends Geometry {
 	
-	private List<Geometry> geometry;
+	private List<Geometry> geometries;
+
+	public GeometryCollection() {
+		super(GeometryCollection.class.getSimpleName());
+	}
 	
 	public GeometryCollection(List<Geometry> geometry) {
 		super(GeometryCollection.class.getSimpleName());
-		this.geometry = geometry;
+		this.geometries = geometry;
 	}
 	
 	public List<Geometry> getGeometries() {
-		return geometry;
+		return geometries;
 	}
 }

--- a/src/main/java/org/geojson/geometry/GeometryCollection.java
+++ b/src/main/java/org/geojson/geometry/GeometryCollection.java
@@ -5,26 +5,20 @@ import java.util.List;
 
 @JsonTypeName("GeometryCollection")
 public class GeometryCollection extends Geometry {
-	
+
 	private List<Geometry> geometries;
-	
+
 	public GeometryCollection() {
-		
+		super(GeometryCollection.class.getSimpleName());
 	}
-	
+
 	public GeometryCollection(List<Geometry> geometry) {
+		this();
 		this.geometries = geometry;
-//		setType( GeometryCollection.class.getSimpleName() );
 	}
-	
+
 	public List<Geometry> getGeometries() {
 		return geometries;
 	}
 
-	@Override
-	public String getType() {
-		return GeometryCollection.class.getSimpleName();
-	}
-	
-	
 }

--- a/src/main/java/org/geojson/geometry/GeometryCollection.java
+++ b/src/main/java/org/geojson/geometry/GeometryCollection.java
@@ -1,7 +1,7 @@
 package org.geojson.geometry;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.List;
+import org.codehaus.jackson.annotate.JsonTypeName;
 
 @JsonTypeName("GeometryCollection")
 public class GeometryCollection extends Geometry {
@@ -9,12 +9,12 @@ public class GeometryCollection extends Geometry {
 	private List<Geometry> geometries;
 	
 	public GeometryCollection() {
-		super(GeometryCollection.class.getSimpleName());
+		
 	}
 	
 	public GeometryCollection(List<Geometry> geometry) {
-		this();
 		this.geometries = geometry;
+		setType( GeometryCollection.class.getSimpleName() );
 	}
 	
 	public List<Geometry> getGeometries() {

--- a/src/main/java/org/geojson/geometry/LineString.java
+++ b/src/main/java/org/geojson/geometry/LineString.java
@@ -5,19 +5,27 @@ import java.util.List;
 
 public class LineString extends Geometry {
 	
-	private List<Point> coordinates;
+	private List<double[]> coordinates;
+
+	public LineString() {
+		super( LineString.class.getSimpleName() );
+	}
 	
 	public LineString(List<Point> coordinates) {
 		super(LineString.class.getSimpleName());
-		this.coordinates = coordinates;
+		if ( coordinates != null ) {
+			this.coordinates = new ArrayList<double[]>();
+			
+			for ( Point point : coordinates ) {
+				this.coordinates.add( point.getCoordinates() );
+			}
+		}
+		
 	}
 	
 	public List<double[]> getCoordinates() {
-		List<double[]> doubleArray = new ArrayList<double[]>();
-		for (Point coords: coordinates) {
-			doubleArray.add(coords.getCoordinates());
-		}
-		return doubleArray;
+		return coordinates;
 	}
+	
 }
 

--- a/src/main/java/org/geojson/geometry/LineString.java
+++ b/src/main/java/org/geojson/geometry/LineString.java
@@ -1,8 +1,8 @@
 package org.geojson.geometry;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
+import org.codehaus.jackson.annotate.JsonTypeName;
 
 @JsonTypeName("LineString")
 public class LineString extends Geometry {
@@ -10,18 +10,20 @@ public class LineString extends Geometry {
 	private List<double[]> coordinates;
 
 	public LineString() {
-		super( LineString.class.getSimpleName() );
+
 	}
 	
 	public LineString(List<Point> coordinates) {
-		super(LineString.class.getSimpleName());
+		
 		if ( coordinates != null ) {
-			this.coordinates = new ArrayList<double[]>();
+			this.coordinates = new ArrayList<>();
 			
 			for ( Point point : coordinates ) {
 				this.coordinates.add( point.getCoordinates() );
 			}
 		}
+		
+		setType( LineString.class.getSimpleName() );
 		
 	}
 	
@@ -30,4 +32,3 @@ public class LineString extends Geometry {
 	}
 	
 }
-

--- a/src/main/java/org/geojson/geometry/LineString.java
+++ b/src/main/java/org/geojson/geometry/LineString.java
@@ -6,34 +6,27 @@ import java.util.List;
 
 @JsonTypeName("LineString")
 public class LineString extends Geometry {
-	
+
 	private List<double[]> coordinates;
 
 	public LineString() {
-
+		super(LineString.class.getSimpleName());
 	}
-	
+
 	public LineString(List<Point> coordinates) {
-		
-		if ( coordinates != null ) {
+		this();
+		if (coordinates != null) {
 			this.coordinates = new ArrayList<>();
-			
-			for ( Point point : coordinates ) {
-				this.coordinates.add( point.getCoordinates() );
+
+			for (Point point : coordinates) {
+				this.coordinates.add(point.getCoordinates());
 			}
 		}
-		
-//		setType( LineString.class.getSimpleName() );
-		
+
 	}
-	
+
 	public List<double[]> getCoordinates() {
 		return coordinates;
 	}
 
-	@Override
-	public String getType() {
-		return LineString.class.getSimpleName();
-	}
-	
 }

--- a/src/main/java/org/geojson/geometry/LineString.java
+++ b/src/main/java/org/geojson/geometry/LineString.java
@@ -1,8 +1,10 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonTypeName("LineString")
 public class LineString extends Geometry {
 	
 	private List<double[]> coordinates;

--- a/src/main/java/org/geojson/geometry/LineString.java
+++ b/src/main/java/org/geojson/geometry/LineString.java
@@ -1,8 +1,8 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
-import org.codehaus.jackson.annotate.JsonTypeName;
 
 @JsonTypeName("LineString")
 public class LineString extends Geometry {
@@ -23,12 +23,17 @@ public class LineString extends Geometry {
 			}
 		}
 		
-		setType( LineString.class.getSimpleName() );
+//		setType( LineString.class.getSimpleName() );
 		
 	}
 	
 	public List<double[]> getCoordinates() {
 		return coordinates;
+	}
+
+	@Override
+	public String getType() {
+		return LineString.class.getSimpleName();
 	}
 	
 }

--- a/src/main/java/org/geojson/geometry/MultiLineString.java
+++ b/src/main/java/org/geojson/geometry/MultiLineString.java
@@ -1,8 +1,10 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonTypeName("MultiLineString")
 public class MultiLineString extends Geometry {
 	
 	private List<List<double[]>> coordinates;

--- a/src/main/java/org/geojson/geometry/MultiLineString.java
+++ b/src/main/java/org/geojson/geometry/MultiLineString.java
@@ -1,35 +1,33 @@
 package org.geojson.geometry;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
-@JsonTypeName("MultiLineString")
 public class MultiLineString extends Geometry {
 	
 	private List<List<double[]>> coordinates;
 
 	public MultiLineString() {
-		super( null );
+		
 	}
 	
 	public MultiLineString(List<LineString> coordinates) {
-		super(MultiLineString.class.getSimpleName());
 		if ( coordinates != null ) {
-			this.coordinates = new ArrayList<List<double[]>>();
+			this.coordinates = new ArrayList<>();
 			
 			for ( LineString coordinate : coordinates ) {
 				this.coordinates.add( coordinate.getCoordinates() );
 			}
 		}
+		
+		setType( MultiLineString.class.getSimpleName() );
 	}
 	
 	public List<List<double[]>> getCoordinates() {
 		return coordinates;
 	}
-	
-	@Override
-	public String getType() {
-		return this.getClass().getSimpleName();
+
+	public void setCoordinates( List<List<double[]>> coordinates ) {
+		this.coordinates = coordinates;
 	}
 }

--- a/src/main/java/org/geojson/geometry/MultiLineString.java
+++ b/src/main/java/org/geojson/geometry/MultiLineString.java
@@ -5,21 +5,28 @@ import java.util.List;
 
 public class MultiLineString extends Geometry {
 	
-	private List<LineString> coordinates;
+	private List<List<double[]>> coordinates;
+
+	public MultiLineString() {
+		super( null );
+	}
 	
 	public MultiLineString(List<LineString> coordinates) {
 		super(MultiLineString.class.getSimpleName());
-		this.coordinates = coordinates;
+		if ( coordinates != null ) {
+			this.coordinates = new ArrayList<List<double[]>>();
+			
+			for ( LineString coordinate : coordinates ) {
+				this.coordinates.add( coordinate.getCoordinates() );
+			}
+		}
 	}
 	
 	public List<List<double[]>> getCoordinates() {
-		List<List<double[]>> multiLineString = new ArrayList<List<double[]>>();
-		for (LineString coordinate : coordinates) {
-			multiLineString.add(coordinate.getCoordinates());
-		}
-		return multiLineString;
+		return coordinates;
 	}
 	
+	@Override
 	public String getType() {
 		return this.getClass().getSimpleName();
 	}

--- a/src/main/java/org/geojson/geometry/MultiLineString.java
+++ b/src/main/java/org/geojson/geometry/MultiLineString.java
@@ -20,7 +20,7 @@ public class MultiLineString extends Geometry {
 			}
 		}
 		
-		setType( MultiLineString.class.getSimpleName() );
+//		setType( MultiLineString.class.getSimpleName() );
 	}
 	
 	public List<List<double[]>> getCoordinates() {
@@ -30,4 +30,11 @@ public class MultiLineString extends Geometry {
 	public void setCoordinates( List<List<double[]>> coordinates ) {
 		this.coordinates = coordinates;
 	}
+
+	@Override
+	public String getType() {
+		return MultiLineString.class.getSimpleName(); 
+	}
+	
+	
 }

--- a/src/main/java/org/geojson/geometry/MultiLineString.java
+++ b/src/main/java/org/geojson/geometry/MultiLineString.java
@@ -1,40 +1,36 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonTypeName("MultiLineString")
 public class MultiLineString extends Geometry {
-	
+
 	private List<List<double[]>> coordinates;
 
 	public MultiLineString() {
-		
+		super(MultiLineString.class.getSimpleName());
 	}
-	
+
 	public MultiLineString(List<LineString> coordinates) {
-		if ( coordinates != null ) {
+		this();
+		if (coordinates != null) {
 			this.coordinates = new ArrayList<>();
-			
-			for ( LineString coordinate : coordinates ) {
-				this.coordinates.add( coordinate.getCoordinates() );
+
+			for (LineString coordinate : coordinates) {
+				this.coordinates.add(coordinate.getCoordinates());
 			}
 		}
-		
-//		setType( MultiLineString.class.getSimpleName() );
+
 	}
-	
+
 	public List<List<double[]>> getCoordinates() {
 		return coordinates;
 	}
 
-	public void setCoordinates( List<List<double[]>> coordinates ) {
+	public void setCoordinates(List<List<double[]>> coordinates) {
 		this.coordinates = coordinates;
 	}
 
-	@Override
-	public String getType() {
-		return MultiLineString.class.getSimpleName(); 
-	}
-	
-	
 }

--- a/src/main/java/org/geojson/geometry/MultiPoint.java
+++ b/src/main/java/org/geojson/geometry/MultiPoint.java
@@ -20,7 +20,7 @@ public class MultiPoint extends Geometry {
 			}
 		}
 		
-		setType( MultiPoint.class.getSimpleName() );
+//		setType( MultiPoint.class.getSimpleName() );
 	}
 	
 	public List<double[]> getCoordinates() {
@@ -30,5 +30,12 @@ public class MultiPoint extends Geometry {
 	public void setCoordinates( List<double[]> coordinates ) {
 		this.coordinates = coordinates;
 	}
+
+	@Override
+	public String getType() {
+		return MultiPoint.class.getSimpleName(); 
+	}
+	
+	
 	
 }

--- a/src/main/java/org/geojson/geometry/MultiPoint.java
+++ b/src/main/java/org/geojson/geometry/MultiPoint.java
@@ -5,21 +5,29 @@ import java.util.List;
 
 public class MultiPoint extends Geometry {
 	
-	private List<Point> coordinates;
+	private List<double[]> coordinates;
+
+	public MultiPoint() {
+		super(MultiPoint.class.getName());
+	}
 	
 	public MultiPoint(List<Point> coordinates) {
 		super(MultiPoint.class.getName());
-		this.coordinates = coordinates;
+		
+		if ( coordinates != null ) {
+			this.coordinates = new ArrayList<double[]>();
+			
+			for ( Point coordinate : coordinates ) {
+				this.coordinates.add( coordinate.getCoordinates() );
+			}
+		}
 	}
 	
 	public List<double[]> getCoordinates() {
-		List<double[]> points = new ArrayList<double[]>();
-		for (Point point : coordinates) {
-			points.add(point.getCoordinates());
-		}
-		return points;
+		return coordinates;
 	}
 	
+	@Override
 	public String getType() {
 		return this.getClass().getSimpleName();
 	}

--- a/src/main/java/org/geojson/geometry/MultiPoint.java
+++ b/src/main/java/org/geojson/geometry/MultiPoint.java
@@ -1,41 +1,36 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonTypeName("MultiPoint")
 public class MultiPoint extends Geometry {
-	
+
 	private List<double[]> coordinates;
 
 	public MultiPoint() {
-
+		super(MultiPoint.class.getSimpleName());
 	}
-	
+
 	public MultiPoint(List<Point> coordinates) {
-		if ( coordinates != null ) {
+		this();
+		if (coordinates != null) {
 			this.coordinates = new ArrayList<>();
-			
-			for ( Point coordinate : coordinates ) {
-				this.coordinates.add( coordinate.getCoordinates() );
+
+			for (Point coordinate : coordinates) {
+				this.coordinates.add(coordinate.getCoordinates());
 			}
 		}
-		
-//		setType( MultiPoint.class.getSimpleName() );
+
 	}
-	
+
 	public List<double[]> getCoordinates() {
 		return coordinates;
 	}
 
-	public void setCoordinates( List<double[]> coordinates ) {
+	public void setCoordinates(List<double[]> coordinates) {
 		this.coordinates = coordinates;
 	}
 
-	@Override
-	public String getType() {
-		return MultiPoint.class.getSimpleName(); 
-	}
-	
-	
-	
 }

--- a/src/main/java/org/geojson/geometry/MultiPoint.java
+++ b/src/main/java/org/geojson/geometry/MultiPoint.java
@@ -1,8 +1,10 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonTypeName("MultiPoint")
 public class MultiPoint extends Geometry {
 	
 	private List<double[]> coordinates;

--- a/src/main/java/org/geojson/geometry/MultiPoint.java
+++ b/src/main/java/org/geojson/geometry/MultiPoint.java
@@ -1,36 +1,34 @@
 package org.geojson.geometry;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
-@JsonTypeName("MultiPoint")
 public class MultiPoint extends Geometry {
 	
 	private List<double[]> coordinates;
 
 	public MultiPoint() {
-		super(MultiPoint.class.getName());
+
 	}
 	
 	public MultiPoint(List<Point> coordinates) {
-		super(MultiPoint.class.getName());
-		
 		if ( coordinates != null ) {
-			this.coordinates = new ArrayList<double[]>();
+			this.coordinates = new ArrayList<>();
 			
 			for ( Point coordinate : coordinates ) {
 				this.coordinates.add( coordinate.getCoordinates() );
 			}
 		}
+		
+		setType( MultiPoint.class.getSimpleName() );
 	}
 	
 	public List<double[]> getCoordinates() {
 		return coordinates;
 	}
-	
-	@Override
-	public String getType() {
-		return this.getClass().getSimpleName();
+
+	public void setCoordinates( List<double[]> coordinates ) {
+		this.coordinates = coordinates;
 	}
+	
 }

--- a/src/main/java/org/geojson/geometry/MultiPolygon.java
+++ b/src/main/java/org/geojson/geometry/MultiPolygon.java
@@ -6,39 +6,31 @@ import java.util.List;
 
 @JsonTypeName("MultiPolygon")
 public class MultiPolygon extends Geometry {
-	
+
 	private List<List<List<double[]>>> coordinates;
 
 	public MultiPolygon() {
-
+		super(MultiPolygon.class.getSimpleName());
 	}
-	
+
 	public MultiPolygon(List<Polygon> coordinates) {
-		if ( coordinates != null ) {
+		this();
+		if (coordinates != null) {
 			this.coordinates = new ArrayList<>();
-			
-			for ( Polygon coordinate : coordinates ) {
-				this.coordinates.add( coordinate.getCoordinates() );
+
+			for (Polygon coordinate : coordinates) {
+				this.coordinates.add(coordinate.getCoordinates());
 			}
 		}
-		
-//		setType( MultiPolygon.class.getSimpleName() );
-		
+
 	}
-	
-	public List<List<List<double[]>>>  getCoordinates() {
+
+	public List<List<List<double[]>>> getCoordinates() {
 		return coordinates;
 	}
 
-	public void setCoordinates( List<List<List<double[]>>> coordinates ) {
+	public void setCoordinates(List<List<List<double[]>>> coordinates) {
 		this.coordinates = coordinates;
 	}
 
-	@Override
-	public String getType() {
-		return MultiPolygon.class.getSimpleName();
-	}
-	
-	
-	
 }

--- a/src/main/java/org/geojson/geometry/MultiPolygon.java
+++ b/src/main/java/org/geojson/geometry/MultiPolygon.java
@@ -1,8 +1,10 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonTypeName("MultiPolygon")
 public class MultiPolygon extends Geometry {
 	
 	private List<List<List<double[]>>> coordinates;

--- a/src/main/java/org/geojson/geometry/MultiPolygon.java
+++ b/src/main/java/org/geojson/geometry/MultiPolygon.java
@@ -1,8 +1,10 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonTypeName("MultiPolygon")
 public class MultiPolygon extends Geometry {
 	
 	private List<List<List<double[]>>> coordinates;
@@ -20,7 +22,7 @@ public class MultiPolygon extends Geometry {
 			}
 		}
 		
-		setType( MultiPolygon.class.getSimpleName() );
+//		setType( MultiPolygon.class.getSimpleName() );
 		
 	}
 	
@@ -31,5 +33,12 @@ public class MultiPolygon extends Geometry {
 	public void setCoordinates( List<List<List<double[]>>> coordinates ) {
 		this.coordinates = coordinates;
 	}
+
+	@Override
+	public String getType() {
+		return MultiPolygon.class.getSimpleName();
+	}
+	
+	
 	
 }

--- a/src/main/java/org/geojson/geometry/MultiPolygon.java
+++ b/src/main/java/org/geojson/geometry/MultiPolygon.java
@@ -1,36 +1,35 @@
 package org.geojson.geometry;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
-@JsonTypeName("MultiPolygon")
 public class MultiPolygon extends Geometry {
 	
 	private List<List<List<double[]>>> coordinates;
 
 	public MultiPolygon() {
-		super(MultiPolygon.class.getSimpleName());
+
 	}
 	
 	public MultiPolygon(List<Polygon> coordinates) {
-		super(MultiPolygon.class.getSimpleName());
 		if ( coordinates != null ) {
-			this.coordinates = new ArrayList<List<List<double[]>>>();
+			this.coordinates = new ArrayList<>();
 			
 			for ( Polygon coordinate : coordinates ) {
 				this.coordinates.add( coordinate.getCoordinates() );
 			}
 		}
 		
+		setType( MultiPolygon.class.getSimpleName() );
+		
 	}
 	
 	public List<List<List<double[]>>>  getCoordinates() {
 		return coordinates;
 	}
-	
-	@Override
-	public String getType() {
-		return this.getClass().getSimpleName();
+
+	public void setCoordinates( List<List<List<double[]>>> coordinates ) {
+		this.coordinates = coordinates;
 	}
+	
 }

--- a/src/main/java/org/geojson/geometry/MultiPolygon.java
+++ b/src/main/java/org/geojson/geometry/MultiPolygon.java
@@ -5,21 +5,29 @@ import java.util.List;
 
 public class MultiPolygon extends Geometry {
 	
-	private List<Polygon> coordinates;
+	private List<List<List<double[]>>> coordinates;
+
+	public MultiPolygon() {
+		super(MultiPolygon.class.getSimpleName());
+	}
 	
 	public MultiPolygon(List<Polygon> coordinates) {
 		super(MultiPolygon.class.getSimpleName());
-		this.coordinates = coordinates;
+		if ( coordinates != null ) {
+			this.coordinates = new ArrayList<List<List<double[]>>>();
+			
+			for ( Polygon coordinate : coordinates ) {
+				this.coordinates.add( coordinate.getCoordinates() );
+			}
+		}
+		
 	}
 	
 	public List<List<List<double[]>>>  getCoordinates() {
-		List<List<List<double[]>>> multiPolygon = new ArrayList<List<List<double[]>>>();
-		for (Polygon polygon: coordinates) {
-			multiPolygon.add(polygon.getCoordinates());
-		}
-		return multiPolygon;
+		return coordinates;
 	}
 	
+	@Override
 	public String getType() {
 		return this.getClass().getSimpleName();
 	}

--- a/src/main/java/org/geojson/geometry/Point.java
+++ b/src/main/java/org/geojson/geometry/Point.java
@@ -1,16 +1,14 @@
 package org.geojson.geometry;
 
-import org.codehaus.jackson.annotate.JsonTypeInfo;
-import org.codehaus.jackson.annotate.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("Point")
-@JsonTypeInfo(use = JsonTypeInfo.Id.NONE, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public class Point extends Geometry {
 	
 	private double[] coordinates;
 
 	public Point() {
-
+//		setType( Point.class.getSimpleName() );
 	}
 	
 	public Point(double longtitude, double latitude) {		
@@ -18,7 +16,7 @@ public class Point extends Geometry {
 		coordinates[0] = longtitude;
 		coordinates[1] = latitude;
 		
-		setType( Point.class.getSimpleName() );
+//		setType( Point.class.getSimpleName() );
 	}
 
 	public Point(double longtitude, double latitude, double altitude) {
@@ -27,7 +25,7 @@ public class Point extends Geometry {
 		coordinates[1] = latitude;
 		coordinates[2] = latitude;
 		
-		setType( Point.class.getSimpleName() );
+//		setType( Point.class.getSimpleName() );
 	}
 
 	public double[] getCoordinates() {
@@ -36,6 +34,11 @@ public class Point extends Geometry {
 
 	public void setCoordinates( double[] coordinates ) {
 		this.coordinates = coordinates;
+	}
+
+	@Override
+	public String getType() {
+		return Point.class.getSimpleName();
 	}
 
 	

--- a/src/main/java/org/geojson/geometry/Point.java
+++ b/src/main/java/org/geojson/geometry/Point.java
@@ -1,37 +1,42 @@
 package org.geojson.geometry;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.codehaus.jackson.annotate.JsonTypeInfo;
+import org.codehaus.jackson.annotate.JsonTypeName;
 
 @JsonTypeName("Point")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public class Point extends Geometry {
 	
 	private double[] coordinates;
 
 	public Point() {
-		super(Point.class.getSimpleName());
+
 	}
 	
 	public Point(double longtitude, double latitude) {		
-		super(Point.class.getSimpleName());
-
 		coordinates = new double[2];
 		coordinates[0] = longtitude;
 		coordinates[1] = latitude;
+		
+		setType( Point.class.getSimpleName() );
 	}
 
 	public Point(double longtitude, double latitude, double altitude) {
-		super(Point.class.getSimpleName());
-
 		coordinates = new double[3];
 		coordinates[0] = longtitude;
 		coordinates[1] = latitude;
 		coordinates[2] = latitude;
+		
+		setType( Point.class.getSimpleName() );
 	}
 
 	public double[] getCoordinates() {
 		return coordinates;
 	}
 
-	
+	public void setCoordinates( double[] coordinates ) {
+		this.coordinates = coordinates;
+	}
+
 	
 }

--- a/src/main/java/org/geojson/geometry/Point.java
+++ b/src/main/java/org/geojson/geometry/Point.java
@@ -4,42 +4,36 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("Point")
 public class Point extends Geometry {
-	
+
 	private double[] coordinates;
 
 	public Point() {
-//		setType( Point.class.getSimpleName() );
+		super(Point.class.getSimpleName());
 	}
-	
-	public Point(double longtitude, double latitude) {		
+
+	public Point(double longtitude, double latitude) {
+		this();
 		coordinates = new double[2];
 		coordinates[0] = longtitude;
 		coordinates[1] = latitude;
-		
-//		setType( Point.class.getSimpleName() );
+
 	}
 
 	public Point(double longtitude, double latitude, double altitude) {
+		this();
 		coordinates = new double[3];
 		coordinates[0] = longtitude;
 		coordinates[1] = latitude;
 		coordinates[2] = latitude;
-		
-//		setType( Point.class.getSimpleName() );
+
 	}
 
 	public double[] getCoordinates() {
 		return coordinates;
 	}
 
-	public void setCoordinates( double[] coordinates ) {
+	public void setCoordinates(double[] coordinates) {
 		this.coordinates = coordinates;
 	}
 
-	@Override
-	public String getType() {
-		return Point.class.getSimpleName();
-	}
-
-	
 }

--- a/src/main/java/org/geojson/geometry/Point.java
+++ b/src/main/java/org/geojson/geometry/Point.java
@@ -3,6 +3,10 @@ package org.geojson.geometry;
 public class Point extends Geometry {
 	
 	private double[] coordinates;
+
+	public Point() {
+		super(Point.class.getSimpleName());
+	}
 	
 	public Point(double longtitude, double latitude) {		
 		super(Point.class.getSimpleName());
@@ -24,4 +28,7 @@ public class Point extends Geometry {
 	public double[] getCoordinates() {
 		return coordinates;
 	}
+
+	
+	
 }

--- a/src/main/java/org/geojson/geometry/Point.java
+++ b/src/main/java/org/geojson/geometry/Point.java
@@ -1,5 +1,8 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("Point")
 public class Point extends Geometry {
 	
 	private double[] coordinates;

--- a/src/main/java/org/geojson/geometry/Polygon.java
+++ b/src/main/java/org/geojson/geometry/Polygon.java
@@ -19,7 +19,7 @@ public class Polygon extends Geometry {
 			}
 		}
 		
-		setType( Polygon.class.getSimpleName() );
+//		setType( Polygon.class.getSimpleName() );
 		
 	}
 	
@@ -27,4 +27,11 @@ public class Polygon extends Geometry {
 	public List<List<double[]>> getCoordinates() {
 		return coordinates;
 	}
+
+	@Override
+	public String getType() {
+		return Polygon.class.getSimpleName();
+	}
+	
+	
 }

--- a/src/main/java/org/geojson/geometry/Polygon.java
+++ b/src/main/java/org/geojson/geometry/Polygon.java
@@ -1,8 +1,10 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonTypeName("Polygon")
 public class Polygon extends Geometry {
 	
 	private List<List<double[]>> coordinates;

--- a/src/main/java/org/geojson/geometry/Polygon.java
+++ b/src/main/java/org/geojson/geometry/Polygon.java
@@ -1,26 +1,25 @@
 package org.geojson.geometry;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
-@JsonTypeName("Polygon")
 public class Polygon extends Geometry {
 	
 	private List<List<double[]>> coordinates;
 
 	public Polygon() {
-		super(Polygon.class.getSimpleName());
+
 	}
 	
 	public Polygon(List<LineString> coordinates) {
-		super(Polygon.class.getSimpleName());
 		if ( coordinates != null ) {
-			this.coordinates = new ArrayList<List<double[]>>();
+			this.coordinates = new ArrayList<>();
 			for ( LineString coordinate : coordinates ) {
 				this.coordinates.add( coordinate.getCoordinates() );
 			}
 		}
+		
+		setType( Polygon.class.getSimpleName() );
 		
 	}
 	

--- a/src/main/java/org/geojson/geometry/Polygon.java
+++ b/src/main/java/org/geojson/geometry/Polygon.java
@@ -1,28 +1,30 @@
 package org.geojson.geometry;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonTypeName("Polygon")
 public class Polygon extends Geometry {
-	
+
 	private List<List<double[]>> coordinates;
 
 	public Polygon() {
-
+		super(Polygon.class.getSimpleName());
 	}
-	
+
 	public Polygon(List<LineString> coordinates) {
-		if ( coordinates != null ) {
+		this();
+
+		if (coordinates != null) {
 			this.coordinates = new ArrayList<>();
-			for ( LineString coordinate : coordinates ) {
-				this.coordinates.add( coordinate.getCoordinates() );
+			for (LineString coordinate : coordinates) {
+				this.coordinates.add(coordinate.getCoordinates());
 			}
 		}
-		
-//		setType( Polygon.class.getSimpleName() );
-		
+
 	}
-	
+
 	// Should throw is not a polygon exception
 	public List<List<double[]>> getCoordinates() {
 		return coordinates;
@@ -32,6 +34,5 @@ public class Polygon extends Geometry {
 	public String getType() {
 		return Polygon.class.getSimpleName();
 	}
-	
-	
+
 }

--- a/src/main/java/org/geojson/geometry/Polygon.java
+++ b/src/main/java/org/geojson/geometry/Polygon.java
@@ -5,19 +5,25 @@ import java.util.List;
 
 public class Polygon extends Geometry {
 	
-	private List<LineString> coordinates;
+	private List<List<double[]>> coordinates;
+
+	public Polygon() {
+		super(Polygon.class.getSimpleName());
+	}
 	
 	public Polygon(List<LineString> coordinates) {
 		super(Polygon.class.getSimpleName());
-		this.coordinates = coordinates;
+		if ( coordinates != null ) {
+			this.coordinates = new ArrayList<List<double[]>>();
+			for ( LineString coordinate : coordinates ) {
+				this.coordinates.add( coordinate.getCoordinates() );
+			}
+		}
+		
 	}
 	
 	// Should throw is not a polygon exception
 	public List<List<double[]>> getCoordinates() {
-		List<List<double[]>> polygon = new ArrayList<List<double[]>>();
-		for (LineString lineString : coordinates) {
-			polygon.add(lineString.getCoordinates());
-		}
-		return polygon;
+		return coordinates;
 	}
 }

--- a/src/main/java/org/geojson/object/Feature.java
+++ b/src/main/java/org/geojson/object/Feature.java
@@ -23,6 +23,10 @@ public class Feature {
 	public Geometry getGeometry() {
 		return geometry;
 	}
+
+	public void setGeometry( Geometry geometry ) {
+		this.geometry = geometry;
+	}
 	
 	public Map<String, String> getProperties() {
 		return properties;

--- a/src/main/java/org/geojson/object/Feature.java
+++ b/src/main/java/org/geojson/object/Feature.java
@@ -10,6 +10,9 @@ public class Feature {
 	private Map<String, Serializable> properties;
 	private Geometry geometry;
 
+	public Feature() {
+	}
+
 	public Feature(Geometry geometry) {
 		this.geometry = geometry;
 	}

--- a/src/main/java/org/geojson/object/Feature.java
+++ b/src/main/java/org/geojson/object/Feature.java
@@ -1,13 +1,12 @@
 package org.geojson.object;
 
-import java.io.Serializable;
 import java.util.Map;
 import org.geojson.geometry.Geometry;
 
 public class Feature {
 	
 	private final String type = "Feature";
-	private Map<String, Serializable> properties;
+	private Map<String, String> properties;
 	private Geometry geometry;
 
 	public Feature() {
@@ -25,11 +24,11 @@ public class Feature {
 		return geometry;
 	}
 	
-	public Map<String, Serializable> getProperties() {
+	public Map<String, String> getProperties() {
 		return properties;
 	}
 	
-	public void setProperties(Map<String, Serializable> properties) {
+	public void setProperties(Map<String, String> properties) {
 		this.properties = properties;
 	}
 }

--- a/src/main/java/org/geojson/object/Feature.java
+++ b/src/main/java/org/geojson/object/Feature.java
@@ -6,7 +6,7 @@ import org.geojson.geometry.Geometry;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Feature {
-	
+
 	private final String type = "Feature";
 	private Map<String, String> properties;
 	private Geometry geometry;
@@ -17,7 +17,7 @@ public class Feature {
 	public Feature(Geometry geometry) {
 		this.geometry = geometry;
 	}
-	
+
 	public String getType() {
 		return type;
 	}
@@ -26,14 +26,14 @@ public class Feature {
 		return geometry;
 	}
 
-	public void setGeometry( Geometry geometry ) {
+	public void setGeometry(Geometry geometry) {
 		this.geometry = geometry;
 	}
-	
+
 	public Map<String, String> getProperties() {
 		return properties;
 	}
-	
+
 	public void setProperties(Map<String, String> properties) {
 		this.properties = properties;
 	}

--- a/src/main/java/org/geojson/object/Feature.java
+++ b/src/main/java/org/geojson/object/Feature.java
@@ -1,8 +1,10 @@
 package org.geojson.object;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Map;
 import org.geojson.geometry.Geometry;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Feature {
 	
 	private final String type = "Feature";

--- a/src/main/java/org/geojson/object/FeatureCollection.java
+++ b/src/main/java/org/geojson/object/FeatureCollection.java
@@ -6,6 +6,9 @@ public class FeatureCollection {
 	
 	private final String type = "FeatureCollection";
 	private List<Feature> features;
+
+	public FeatureCollection() {
+	}
 	
 	public FeatureCollection(List<Feature> features) {
 		this.features = features;

--- a/src/main/java/org/geojson/object/FeatureCollection.java
+++ b/src/main/java/org/geojson/object/FeatureCollection.java
@@ -2,6 +2,7 @@ package org.geojson.object;
 
 import java.util.List;
 
+
 public class FeatureCollection {
 	
 	private final String type = "FeatureCollection";
@@ -17,8 +18,12 @@ public class FeatureCollection {
 	public String getType() {
 		return this.type;
 	}
-	
-	public Feature[] getFeatures() {
-		return features.toArray(new Feature[0]);
+
+	public List<Feature> getFeatures() {
+		return features;
+	}
+
+	public void setFeatures( List<Feature> features ) {
+		this.features = features;
 	}
 }

--- a/src/main/java/org/geojson/object/FeatureCollection.java
+++ b/src/main/java/org/geojson/object/FeatureCollection.java
@@ -2,19 +2,18 @@ package org.geojson.object;
 
 import java.util.List;
 
-
 public class FeatureCollection {
-	
+
 	private final String type = "FeatureCollection";
 	private List<Feature> features;
 
 	public FeatureCollection() {
 	}
-	
+
 	public FeatureCollection(List<Feature> features) {
 		this.features = features;
 	}
-	
+
 	public String getType() {
 		return this.type;
 	}
@@ -23,7 +22,7 @@ public class FeatureCollection {
 		return features;
 	}
 
-	public void setFeatures( List<Feature> features ) {
+	public void setFeatures(List<Feature> features) {
 		this.features = features;
 	}
 }

--- a/src/main/java/org/geojson/object/IdentifiedFeature.java
+++ b/src/main/java/org/geojson/object/IdentifiedFeature.java
@@ -3,20 +3,21 @@ package org.geojson.object;
 import org.geojson.geometry.Geometry;
 
 /**
- * Make it possible to construct features that have an "id" identifier.
- * From http://geojson.org/geojson-spec.html:
- *	If a feature has a commonly used identifier,
- *	that identifier should be included as a member of the feature object with the name "id".
+ * Make it possible to construct features that have an "id" identifier. From
+ * http://geojson.org/geojson-spec.html: If a feature has a commonly used
+ * identifier, that identifier should be included as a member of the feature
+ * object with the name "id".
  */
 public class IdentifiedFeature extends Feature {
+
 	private String id;
 
 	public IdentifiedFeature() {
 	}
-	
+
 	public IdentifiedFeature(Geometry geometry, String identifier) {
 		super(geometry);
-		id=identifier;
+		id = identifier;
 	}
 
 	public String getId() {

--- a/src/main/java/org/geojson/object/IdentifiedFeature.java
+++ b/src/main/java/org/geojson/object/IdentifiedFeature.java
@@ -8,10 +8,12 @@ import org.geojson.geometry.Geometry;
  *	If a feature has a commonly used identifier,
  *	that identifier should be included as a member of the feature object with the name "id".
  */
-public class IdentifiedFeature extends Feature
-{
+public class IdentifiedFeature extends Feature {
 	private String id;
 
+	public IdentifiedFeature() {
+	}
+	
 	public IdentifiedFeature(Geometry geometry, String identifier) {
 		super(geometry);
 		id=identifier;

--- a/src/main/java/org/geojson/util/GeometryMixin.java
+++ b/src/main/java/org/geojson/util/GeometryMixin.java
@@ -1,0 +1,32 @@
+
+package org.geojson.util;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.geojson.geometry.GeometryCollection;
+import org.geojson.geometry.LineString;
+import org.geojson.geometry.MultiLineString;
+import org.geojson.geometry.MultiPoint;
+import org.geojson.geometry.MultiPolygon;
+import org.geojson.geometry.Point;
+import org.geojson.geometry.Polygon;
+
+/**
+ * Use this mixin with ObjectMapper when deserializing GeoJSON strings, and avoid it while serializing.
+ * 
+ * This is a temporary workaround to the Polymorphic handling of Geometry subtypes while 
+ * serializing with the JsonTypeInfo and JsonSubTypes annotations enabled.
+ *
+ * @author kenny
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({ @JsonSubTypes.Type(value = Point.class, name = "Point"),
+		@JsonSubTypes.Type(value = MultiPoint.class, name = "MultiPoint"),
+		@JsonSubTypes.Type(value = LineString.class, name = "LineString"),
+		@JsonSubTypes.Type(value = MultiLineString.class, name = "MultiLineString"),
+		@JsonSubTypes.Type(value = Polygon.class, name = "Polygon"),
+		@JsonSubTypes.Type(value = MultiPolygon.class, name = "MultiPolygon"),
+		@JsonSubTypes.Type(value = GeometryCollection.class, name = "GeometryCollection") })
+public class GeometryMixin {
+	
+}

--- a/src/main/java/org/geojson/util/GeometryMixin.java
+++ b/src/main/java/org/geojson/util/GeometryMixin.java
@@ -1,4 +1,3 @@
-
 package org.geojson.util;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -12,21 +11,24 @@ import org.geojson.geometry.Point;
 import org.geojson.geometry.Polygon;
 
 /**
- * Use this mixin with ObjectMapper when deserializing GeoJSON strings, and avoid it while serializing.
- * 
- * This is a temporary workaround to the Polymorphic handling of Geometry subtypes while 
- * serializing with the JsonTypeInfo and JsonSubTypes annotations enabled.
+ * Use this mixin with ObjectMapper when deserializing GeoJSON strings, and
+ * avoid it while serializing.
+ *
+ * This is a temporary workaround to the Polymorphic handling of Geometry
+ * subtypes while serializing with the JsonTypeInfo and JsonSubTypes annotations
+ * enabled.
  *
  * @author kenny
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-@JsonSubTypes({ @JsonSubTypes.Type(value = Point.class, name = "Point"),
-		@JsonSubTypes.Type(value = MultiPoint.class, name = "MultiPoint"),
-		@JsonSubTypes.Type(value = LineString.class, name = "LineString"),
-		@JsonSubTypes.Type(value = MultiLineString.class, name = "MultiLineString"),
-		@JsonSubTypes.Type(value = Polygon.class, name = "Polygon"),
-		@JsonSubTypes.Type(value = MultiPolygon.class, name = "MultiPolygon"),
-		@JsonSubTypes.Type(value = GeometryCollection.class, name = "GeometryCollection") })
+@JsonSubTypes({
+	@JsonSubTypes.Type(value = Point.class, name = "Point"),
+	@JsonSubTypes.Type(value = MultiPoint.class, name = "MultiPoint"),
+	@JsonSubTypes.Type(value = LineString.class, name = "LineString"),
+	@JsonSubTypes.Type(value = MultiLineString.class, name = "MultiLineString"),
+	@JsonSubTypes.Type(value = Polygon.class, name = "Polygon"),
+	@JsonSubTypes.Type(value = MultiPolygon.class, name = "MultiPolygon"),
+	@JsonSubTypes.Type(value = GeometryCollection.class, name = "GeometryCollection")})
 public class GeometryMixin {
-	
+
 }

--- a/src/test/java/org/geojson/object/FeatureCollectionTest.java
+++ b/src/test/java/org/geojson/object/FeatureCollectionTest.java
@@ -2,6 +2,7 @@ package org.geojson.object;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +22,7 @@ import org.junit.Test;
 
 public class FeatureCollectionTest {
 
-	private ObjectMapper mapper = new ObjectMapper();
+	private final ObjectMapper mapper = new ObjectMapper();
 
 	@Test
 	public void testPointGeometry() throws Exception {
@@ -32,6 +33,10 @@ public class FeatureCollectionTest {
 		String expect = "{\"type\":\"Point\",\"coordinates\":[100.0,0.0]}";
 
 		Assert.assertEquals(expect, result);
+		
+		Point readValue = mapper.readValue(expect, Point.class);
+		Assert.assertEquals("[100.0, 0.0]", Arrays.toString( readValue.getCoordinates() ) );
+		Assert.assertEquals("Point", readValue.getType() );
 	}
 
 	@Test
@@ -46,6 +51,12 @@ public class FeatureCollectionTest {
 		String expect = "{\"type\":\"LineString\",\"coordinates\":[[100.0,0.0],[101.0,1.0]]}";
 
 		Assert.assertEquals(expect, result);
+		
+		LineString readValue = mapper.readValue(expect, LineString.class);
+		Assert.assertEquals(2,  readValue.getCoordinates().size() );
+		Assert.assertEquals( "[100.0, 0.0]",  Arrays.toString( readValue.getCoordinates().get(0) ) );
+		Assert.assertEquals( "[101.0, 1.0]",  Arrays.toString( readValue.getCoordinates().get(1) ) );
+		Assert.assertEquals("LineString", readValue.getType() );
 	}
 
 	@Test
@@ -69,6 +80,15 @@ public class FeatureCollectionTest {
 		String expect = "{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}";
 
 		Assert.assertEquals(expect, result);
+		
+		Polygon readValue = mapper.readValue(expect, Polygon.class);
+		Assert.assertEquals(1,  readValue.getCoordinates().size() );
+		Assert.assertEquals( "[100.0, 0.0]",  Arrays.toString( readValue.getCoordinates().get(0).get(0) ) );
+		Assert.assertEquals( "[101.0, 0.0]",  Arrays.toString( readValue.getCoordinates().get(0).get(1) ) );
+		Assert.assertEquals( "[101.0, 1.0]",  Arrays.toString( readValue.getCoordinates().get(0).get(2) ) );
+		Assert.assertEquals( "[100.0, 1.0]",  Arrays.toString( readValue.getCoordinates().get(0).get(3) ) );
+		Assert.assertEquals( "[100.0, 0.0]",  Arrays.toString( readValue.getCoordinates().get(0).get(4) ) );
+		Assert.assertEquals("Polygon", readValue.getType() );
 	}
 	
 	@Test
@@ -100,6 +120,13 @@ public class FeatureCollectionTest {
 		String result = mapper.writeValueAsString(geom);
 		String expect = "{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]],[[100.2,0.2],[100.8,0.2],[100.8,0.8],[100.2,0.8],[100.2,0.2]]]}";
 		Assert.assertEquals(expect, result);
+		
+		Polygon readValue = mapper.readValue(expect, Polygon.class);
+		Assert.assertEquals( 2,  readValue.getCoordinates().size() );
+		Assert.assertEquals( "[100.0, 0.0]",  Arrays.toString( readValue.getCoordinates().get(0).get(0) ) );
+		Assert.assertEquals( "[100.2, 0.2]",  Arrays.toString( readValue.getCoordinates().get(1).get(0) ) );
+		
+		Assert.assertEquals("Polygon", readValue.getType() );
 	}
 
 	@Test
@@ -114,6 +141,12 @@ public class FeatureCollectionTest {
 		String expect = "{\"type\":\"MultiPoint\",\"coordinates\":[[100.0,0.0],[101.0,1.0]]}";
 
 		Assert.assertEquals(expect, result);
+		
+		MultiPoint readValue = mapper.readValue(expect, MultiPoint.class);
+		Assert.assertEquals(2,  readValue.getCoordinates().size() );
+		Assert.assertEquals( "[100.0, 0.0]",  Arrays.toString( readValue.getCoordinates().get(0) ) );
+		Assert.assertEquals( "[101.0, 1.0]",  Arrays.toString( readValue.getCoordinates().get(1) ) );
+		Assert.assertEquals("MultiPoint", readValue.getType() );
 	}
 
 	@Test
@@ -139,6 +172,12 @@ public class FeatureCollectionTest {
 		String expect = "{\"type\":\"MultiLineString\",\"coordinates\":[[[100.0,0.0],[101.0,1.0]],[[102.0,2.0],[103.0,3.0]]]}";
 
 		Assert.assertEquals(expect, result);
+		
+		MultiLineString readValue = mapper.readValue(expect, MultiLineString.class);
+		Assert.assertEquals( 2,  readValue.getCoordinates().size() );
+		Assert.assertEquals( "[100.0, 0.0]",  Arrays.toString( readValue.getCoordinates().get(0).get(0) ) );
+		Assert.assertEquals( "[103.0, 3.0]",  Arrays.toString( readValue.getCoordinates().get(1).get(1) ) );
+		Assert.assertEquals("MultiLineString", readValue.getType() );
 	}
 	
 	@Test
@@ -184,6 +223,12 @@ public class FeatureCollectionTest {
 		String expect = "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[102.0,2.0],[103.0,2.0],[103.0,3.0],[102.0,3.0],[102.0,2.0]]],[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]],[[100.2,0.2],[100.8,0.2],[100.8,0.8],[100.2,0.8],[100.2,0.2]]]]}";
 		
 		Assert.assertEquals(expect, result);
+		
+		MultiPolygon readValue = mapper.readValue(expect, MultiPolygon.class);
+		Assert.assertEquals( 2,  readValue.getCoordinates().size() );
+		Assert.assertEquals( 2,  readValue.getCoordinates().get(1).size() );
+		Assert.assertEquals( 5,  readValue.getCoordinates().get(1).get(0).size() );
+		Assert.assertEquals("MultiPolygon", readValue.getType() );
 	}
 	
 	@Test
@@ -206,6 +251,12 @@ public class FeatureCollectionTest {
 		String result = mapper.writeValueAsString(geometryCollection);
 		String expected = "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[100.0,0.0]},{\"type\":\"LineString\",\"coordinates\":[[101.0,0.0],[102.0,1.0]]}]}";
 		Assert.assertEquals(expected, result);
+		
+//		GeometryCollection readValue = mapper.readValue(expected, GeometryCollection.class);
+//		Assert.assertEquals( 2,  readValue.getCoordinates().size() );
+//		Assert.assertEquals( 2,  readValue.getCoordinates().get(1).size() );
+//		Assert.assertEquals( 5,  readValue.getCoordinates().get(1).get(0).size() );
+//		Assert.assertEquals("GeometryCollection", readValue.getType() );
 	}
 
 	@Test
@@ -215,7 +266,7 @@ public class FeatureCollectionTest {
 
 		Geometry geometry1 = new Point(38.7471494, -122.1298241);
 		Feature feature1 = new Feature(geometry1);
-		Map<String, Serializable> properties = new HashMap<String, Serializable>();
+		Map<String, String> properties = new HashMap<String, String>();
 		properties.put("popupContent", "Hi!");
 		feature1.setProperties(properties);
 
@@ -223,7 +274,7 @@ public class FeatureCollectionTest {
 
 		Geometry geometry2 = new Point(38.1502833, -122.1283545);
 		Feature feature2 = new IdentifiedFeature(geometry2, "Something");
-		Map<String, Serializable> properties2 = new HashMap<String, Serializable>();
+		Map<String, String> properties2 = new HashMap<String, String>();
 		properties2.put("popupContent", "I am Something.");
 		feature2.setProperties(properties2);
 		
@@ -235,6 +286,12 @@ public class FeatureCollectionTest {
 		String result = mapper.writeValueAsString(featureCollection);
 		String expected = "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"popupContent\":\"Hi!\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[38.7471494,-122.1298241]}},{\"type\":\"Feature\",\"properties\":{\"popupContent\":\"I am Something.\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[38.1502833,-122.1283545]},\"id\":\"Something\"}]}";
 		Assert.assertEquals(expected, result);
+		
+		FeatureCollection readValue = mapper.readValue(expected, FeatureCollection.class);
+//		Assert.assertEquals( 2,  readValue.getCoordinates().size() );
+//		Assert.assertEquals( 2,  readValue.getCoordinates().get(1).size() );
+//		Assert.assertEquals( 5,  readValue.getCoordinates().get(1).get(0).size() );
+//		Assert.assertEquals("GeometryCollection", readValue.getType() );
 	}
 
 }

--- a/src/test/java/org/geojson/object/FeatureCollectionTest.java
+++ b/src/test/java/org/geojson/object/FeatureCollectionTest.java
@@ -1,8 +1,8 @@
 package org.geojson.object;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,11 +18,18 @@ import org.geojson.geometry.MultiPoint;
 import org.geojson.geometry.MultiPolygon;
 import org.geojson.geometry.Point;
 import org.geojson.geometry.Polygon;
+import org.junit.Before;
 import org.junit.Test;
 
 public class FeatureCollectionTest {
 
 	private final ObjectMapper mapper = new ObjectMapper();
+	
+	@Before
+	public void setUp(){
+//		mapper.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);  
+//		System.out.println( mapper.getDeserializationConfig().getPropertyNamingStrategy() );
+	}
 
 	@Test
 	public void testPointGeometry() throws Exception {
@@ -32,9 +39,10 @@ public class FeatureCollectionTest {
 		String result = mapper.writeValueAsString(point);
 		String expect = "{\"type\":\"Point\",\"coordinates\":[100.0,0.0]}";
 
+		System.out.println( result );
 		Assert.assertEquals(expect, result);
 		
-		Point readValue = mapper.readValue(expect, Point.class);
+		Point readValue = ( Point ) mapper.readValue(expect, Point.class);
 		Assert.assertEquals("[100.0, 0.0]", Arrays.toString( readValue.getCoordinates() ) );
 		Assert.assertEquals("Point", readValue.getType() );
 	}
@@ -253,10 +261,25 @@ public class FeatureCollectionTest {
 		Assert.assertEquals(expected, result);
 		
 //		GeometryCollection readValue = mapper.readValue(expected, GeometryCollection.class);
-//		Assert.assertEquals( 2,  readValue.getCoordinates().size() );
+//		Assert.assertEquals( 2,  readValue.getGeometries().size() );
 //		Assert.assertEquals( 2,  readValue.getCoordinates().get(1).size() );
 //		Assert.assertEquals( 5,  readValue.getCoordinates().get(1).get(0).size() );
 //		Assert.assertEquals("GeometryCollection", readValue.getType() );
+	}
+	
+	@Test
+	public void testFeature() throws Exception {
+		Feature feature = new Feature( new Point(100.0, 0.0) );
+		feature.setProperties( Collections.singletonMap( "Place", "Radiation belt" ) );
+		
+		String result = mapper.writeValueAsString(feature);
+		String expected = "{\"type\":\"Feature\",\"properties\":{\"Place\":\"Radiation belt\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[100.0,0.0]}}";
+//		Assert.assertEquals(expected, result);
+		
+		System.out.println( result );
+		Feature readValue = mapper.readValue(result, Feature.class);
+		
+		System.out.println( readValue.getProperties() );
 	}
 
 	@Test
@@ -287,7 +310,7 @@ public class FeatureCollectionTest {
 		String expected = "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"popupContent\":\"Hi!\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[38.7471494,-122.1298241]}},{\"type\":\"Feature\",\"properties\":{\"popupContent\":\"I am Something.\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[38.1502833,-122.1283545]},\"id\":\"Something\"}]}";
 		Assert.assertEquals(expected, result);
 		
-		FeatureCollection readValue = mapper.readValue(expected, FeatureCollection.class);
+//		FeatureCollection readValue = mapper.readValue(expected, FeatureCollection.class);
 //		Assert.assertEquals( 2,  readValue.getCoordinates().size() );
 //		Assert.assertEquals( 2,  readValue.getCoordinates().get(1).size() );
 //		Assert.assertEquals( 5,  readValue.getCoordinates().get(1).get(0).size() );

--- a/src/test/java/org/geojson/object/FeatureCollectionTest.java
+++ b/src/test/java/org/geojson/object/FeatureCollectionTest.java
@@ -264,10 +264,12 @@ public class FeatureCollectionTest {
 		Assert.assertEquals(expected, result);
 		
 		GeometryCollection readValue = deserializer.readValue(expected, GeometryCollection.class);
-//		Assert.assertEquals( 2,  readValue.getGeometries().size() );
-//		Assert.assertEquals( 2,  readValue.getCoordinates().get(1).size() );
-//		Assert.assertEquals( 5,  readValue.getCoordinates().get(1).get(0).size() );
-//		Assert.assertEquals("GeometryCollection", readValue.getType() );
+		Assert.assertEquals( 2,  readValue.getGeometries().size() );
+		Assert.assertTrue( readValue.getGeometries().get(1) instanceof LineString );
+		Assert.assertEquals( "[100.0, 0.0]",  Arrays.toString( ((Point)readValue.getGeometries().get(0)).getCoordinates() ) );
+		Assert.assertEquals( "[101.0, 0.0]",  Arrays.toString( ((LineString)readValue.getGeometries().get(1)).getCoordinates().get(0)) );
+		Assert.assertEquals( "[102.0, 1.0]",  Arrays.toString( ((LineString)readValue.getGeometries().get(1)).getCoordinates().get(1)) );
+		Assert.assertEquals("GeometryCollection", readValue.getType() );
 	}
 	
 	@Test


### PR DESCRIPTION
I felt the need to not only use the POJOs to serialize but also consume GeoJSON data issued through REST endpoints in my Project.

I resorted to using a Mixin class to add type information for the Polymorphized Geometry subtypes. This is because, adding the type information to Geometry.java interfered with Serialization but made Deserialization possible.
A Mixin solved the problem.
